### PR TITLE
[FIX] do not force user to use the new tree view

### DIFF
--- a/quick_purchase/views/purchase_view.xml
+++ b/quick_purchase/views/purchase_view.xml
@@ -13,9 +13,6 @@
                             attrs="{'invisible': [('state', 'not in', ('draft', 'sent'))]}"
                             class="oe_highlight"/>
                 </field>
-                <field name="order_line" position="attributes">
-                    <attribute name="create">0</attribute>
-                </field>
             </field>
         </record>
 


### PR DESCRIPTION
FIX https://github.com/OCA/purchase-workflow/pull/391#discussion_r177078130

regards.